### PR TITLE
Added quality of life improvements

### DIFF
--- a/slick_slides/lib/src/deck/deck.dart
+++ b/slick_slides/lib/src/deck/deck.dart
@@ -7,9 +7,28 @@ import 'package:slick_slides/src/deck/deck_controls.dart';
 import 'package:slick_slides/src/deck/slide_config.dart';
 import 'package:syntax_highlight/syntax_highlight.dart';
 
+/// Represents potential actions or behaviors of the [SlideDeck] based on user interactions.
+/// Each value determines how the presentation should respond to certain user actions,
+/// such as navigating between slides or deciding when to exit.
+enum SlideDeckAction {
+  /// Default state. The slide deck is active and the user can navigate between slides.
+  none,
+
+  /// The presentation will exit when the user navigates to the next slide.
+  exitOnNext,
+
+  /// The presentation will exit when the user navigates to the previous slide.
+  exitOnPrevious,
+
+  /// The presentation will exit when the user navigates either to the next or previous slide.
+  exitOnNextOrPrevious,
+
+  /// When set, the presentation will exit immediately.
+  exit,
+}
+
 class SlickSlides {
   static final highlighters = <String, Highlighter>{};
-
   Future<void> initialize() async {
     WidgetsFlutterBinding.ensureInitialized();
 
@@ -49,12 +68,20 @@ class SlideDeck extends StatefulWidget {
     required this.slides,
     this.theme = const SlideThemeData.dark(),
     this.size,
+    this.presentationMode = SlideDeckAction.none,
+    this.slideDeckAction = SlideDeckAction.none,
     super.key,
   });
 
   final List<Slide> slides;
   final SlideThemeData theme;
   final Size size;
+
+  /// Defaults to [SlideDeckAction.none].
+  /// Allows you to control the behavior of the presentation.
+  /// For example, you can set this to [SlideDeckAction.exitOnNext]
+  /// to exit the presentation when the user navigates to the next slide.
+  final SlideDeckAction slideDeckAction;
 
   /// [size] determines the size of the slides.
   /// We recommend specifying the size of the screen when presenting
@@ -92,6 +119,25 @@ class SlideDeckState extends State<SlideDeck> {
     });
   }
 
+  @override
+  void didUpdateWidget(SlideDeck oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.slideDeckAction != oldWidget.slideDeckAction) {
+      if (widget.slideDeckAction == SlideDeckAction.exit) {
+        if (!mounted) return;
+        Navigator.of(context).maybePop();
+      }
+    }
+  }
+
+  /// Returns true if the presentation should exit.
+  bool _shouldExitOnSlideChange(int delta, SlideDeckAction presentationMode) {
+    return (presentationMode == SlideDeckAction.exitOnNext && delta > 0) ||
+        (presentationMode == SlideDeckAction.exitOnPrevious && delta < 0) ||
+        (presentationMode == SlideDeckAction.exitOnNextOrPrevious);
+  }
+
   void _precacheSlide(int index) {
     if (index >= widget.slides.length || index < 0) {
       return;
@@ -106,7 +152,17 @@ class SlideDeckState extends State<SlideDeck> {
     super.dispose();
   }
 
+  /// Changes the slide by [delta].
+  /// If [delta] is positive, the next slide will be shown.
+  /// If [delta] is negative, the previous slide will be shown.
   void _onChangeSlide(int delta) {
+    // Check if we should exit the presentation based on the slide change direction
+    if (_shouldExitOnSlideChange(delta, widget.slideDeckAction)) {
+      _exitPresentation();
+      return;
+    }
+
+    // Continue handling the slide change.
     var newIndex = _index + delta;
     if (newIndex >= widget.slides.length) {
       newIndex = widget.slides.length - 1;
@@ -153,8 +209,11 @@ class SlideDeckState extends State<SlideDeck> {
 
   @override
   Widget build(BuildContext context) {
+    // If the size is not specified, use the size of the screen.
     final Size size = widget.size ?? MediaQuery.of(context).size;
+
     if (_index >= widget.slides.length) {
+      // If the index is out of bounds, show the last slide.
       _index = widget.slides.length - 1;
     }
 

--- a/slick_slides/lib/src/deck/deck.dart
+++ b/slick_slides/lib/src/deck/deck.dart
@@ -102,8 +102,8 @@ class SlideDeckState extends State<SlideDeck> {
 
   @override
   void dispose() {
-    super.dispose();
     _focusNode.dispose();
+    super.dispose();
   }
 
   void _onChangeSlide(int delta) {

--- a/slick_slides/lib/src/deck/deck.dart
+++ b/slick_slides/lib/src/deck/deck.dart
@@ -48,13 +48,24 @@ class SlideDeck extends StatefulWidget {
   const SlideDeck({
     required this.slides,
     this.theme = const SlideThemeData.dark(),
-    this.size = const Size(1920, 1080),
+    this.size,
     super.key,
   });
 
   final List<Slide> slides;
   final SlideThemeData theme;
   final Size size;
+
+  /// [size] determines the size of the slides.
+  /// We recommend specifying the size of the screen when presenting
+  /// to avoid unexpected results.
+  /// If not specified, this defaults to the size of the screen.
+  ///
+  /// Be aware of potential side effects when there no fixed size is specified.
+  /// A known issue is that the highlighting animation in [ColoredCode]
+  /// may highlight the wrong line(s) when the size of the screen changes
+  /// in either the before or after slides of the animation.
+  final Size? size;
 
   @override
   State<SlideDeck> createState() => SlideDeckState();
@@ -142,6 +153,7 @@ class SlideDeckState extends State<SlideDeck> {
 
   @override
   Widget build(BuildContext context) {
+    final Size size = widget.size ?? MediaQuery.of(context).size;
     if (_index >= widget.slides.length) {
       _index = widget.slides.length - 1;
     }
@@ -168,15 +180,15 @@ class SlideDeckState extends State<SlideDeck> {
           color: Colors.black,
           child: Center(
             child: AspectRatio(
-              aspectRatio: widget.size.aspectRatio,
+              aspectRatio: size.aspectRatio,
               child: Stack(
                 fit: StackFit.expand,
                 children: [
                   FittedBox(
                     fit: BoxFit.contain,
                     child: SizedBox(
-                      width: widget.size.width,
-                      height: widget.size.height,
+                      width: size.width,
+                      height: size.height,
                       child: SlideTheme(
                         data: widget.theme,
                         child: HeroControllerScope(

--- a/slick_slides/lib/src/deck/deck.dart
+++ b/slick_slides/lib/src/deck/deck.dart
@@ -68,14 +68,17 @@ class SlideDeck extends StatefulWidget {
     required this.slides,
     this.theme = const SlideThemeData.dark(),
     this.size,
-    this.presentationMode = SlideDeckAction.none,
+    this.onSlideChanged,
     this.slideDeckAction = SlideDeckAction.none,
     super.key,
   });
 
   final List<Slide> slides;
   final SlideThemeData theme;
-  final Size size;
+
+  /// Listener that is called when the slide is changed.
+  /// Can be used to determine when to exit the presentation.
+  final void Function(int index)? onSlideChanged;
 
   /// Defaults to [SlideDeckAction.none].
   /// Allows you to control the behavior of the presentation.
@@ -182,6 +185,9 @@ class SlideDeckState extends State<SlideDeck> {
         );
       });
       _index = newIndex;
+
+      // Notify the listener that the slide has changed.
+      widget.onSlideChanged?.call(_index);
     }
   }
 

--- a/slick_slides/lib/src/deck/deck.dart
+++ b/slick_slides/lib/src/deck/deck.dart
@@ -155,6 +155,9 @@ class SlideDeckState extends State<SlideDeck> {
         } else if (event is RawKeyDownEvent &&
             event.logicalKey == LogicalKeyboardKey.arrowLeft) {
           _onChangeSlide(-1);
+        } else if (event is RawKeyDownEvent &&
+            event.logicalKey == LogicalKeyboardKey.escape) {
+          _exitPresentation();
         }
         return KeyEventResult.handled;
       },
@@ -258,5 +261,11 @@ class SlideDeckState extends State<SlideDeck> {
         return slideWidget;
       });
     }
+  }
+
+  /// Exits the presentation by popping the route.
+  void _exitPresentation() {
+    if (!mounted) return;
+    Navigator.of(context).maybePop();
   }
 }


### PR DESCRIPTION
## Features

- ESC key to exit slide deck (pop route)
- Optional: Added actions (of type `SlideDeckAction`) to exit slide deck based on the following events: 
-- Immediately
-- Upon visiting next slide
-- Upon visiting previous slide
-- Upon either next or previous slide
- Optional: New listener to read the current slide index. 

## Example usage

Imagine having 2 routes.
Route 1: Your primary page (e.g. Scaffold). Somewhere on this page lies a button that pushes you to route 2.
Route 2: A page that returns SlideDeck(...).

You are now able to listen for slide changes thanks to the `onSlideChanged` property in `SlideDeck`. By leveraging this, you check determine whether the last slide has been reached (e.g. `if (index == mySlides.length - 1){...};` . 

Within that `if` condition, you could change the state to update the new `slideDeckAction` paramater from `SlideDeckAction.none` (default) to `SlideDeckAction.exit`. This causes to pop away the route if there is anything underneath, otherwise it will be ignored. Be aware that this approach means that the reaching last slide will cause to exit the view and thus the slide can not be seen. To resolve this, consider using `SlideDeckAction.exitOnNext` instead.